### PR TITLE
Allow default value in get()

### DIFF
--- a/LocalStorageHandler.js
+++ b/LocalStorageHandler.js
@@ -27,13 +27,15 @@
         /**
          * @method get
          * @param key {String} Item key
+         * @param def_val {String|Object} Default Value
          * @return {String|Object|Null}
          */
-        this.get = function(key) {
+        this.get = function(key, def_val) {
+            def_val = (typeof def_val === 'undefined') ? null : def_val;
             try {
-                return JSON.parse(_ls.getItem(key));
+                return JSON.parse(_ls.getItem(key)) || def_val;
             } catch(e) {
-                return _ls.getItem(key);
+                return _ls.getItem(key) || def_val;
             }
         };
 


### PR DESCRIPTION
Proposal: Modification to get() method to allow a default value that will be returned if "key" is not present in localStorage ( ls.getItem(key) === null  )